### PR TITLE
fix: add missing command

### DIFF
--- a/cmd/jen/cmd/root.go
+++ b/cmd/jen/cmd/root.go
@@ -5,6 +5,7 @@ import (
 	"github.com/silphid/jen/cmd/jen/cmd/exec"
 	"github.com/silphid/jen/cmd/jen/cmd/export"
 	"github.com/silphid/jen/cmd/jen/cmd/internal"
+	"github.com/silphid/jen/cmd/jen/cmd/list"
 	"github.com/silphid/jen/cmd/jen/cmd/pull"
 	"github.com/silphid/jen/cmd/jen/cmd/require"
 	"github.com/silphid/jen/cmd/jen/cmd/shell"
@@ -34,6 +35,7 @@ continues to support you throughout development in executing project-related com
 	c.AddCommand(do.New(&options))
 	c.AddCommand(exec.New(&options))
 	c.AddCommand(shell.New(&options))
+	c.AddCommand(list.New(&options))
 	c.AddCommand(export.New(&options))
 	c.AddCommand(require.New(&options))
 	return c


### PR DESCRIPTION
`list` command is missing from the current version

add the missing command to root